### PR TITLE
fixed bug where init.author.url was not appearing correctly in package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ function getParams(done) {
     var data = {
       user: {
           name: config.get('init.author.name')
-        , site: config.get('init.author.url')||''
+        , url: config.get('init.author.url')||''
         , email: config.get('init.author.email')
         , github: config.get('init.author.github')
         , username: config.get('username')


### PR DESCRIPTION
I noticed the site URL I had set with `npm set init.author.url` wasn't making its way into the `package.json` template.

It looks like it was due to a typo. I couldn't find `data.user.site` being used anywhere, so it seemed likely that it was supposed to be `data.user.url`.

Thanks to you and @hughsk for your work on this!